### PR TITLE
final edit on modal on subspage, added a registrations page

### DIFF
--- a/app/assets/stylesheets/pages/_flower_subscription.scss
+++ b/app/assets/stylesheets/pages/_flower_subscription.scss
@@ -289,6 +289,8 @@ hr {
 	&:hover {
 		background-color: $my-orange;
 		border-color: $my-blue;
+    opacity: 0.8;
+      transition: 0.01s;
 	}
 }
 

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -1,0 +1,7 @@
+class RegistrationsController < Devise::RegistrationsController
+  protected
+
+  def after_sign_up_path_for(resource)
+   flower_subscriptions_path
+  end
+end

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -37,10 +37,25 @@ document.addEventListener('turbolinks:load', () => {
   initScrollClick();
 
 
+  const closeButton = document.querySelector('#close_button')
 
-  document.querySelector('#cancel_edit').addEventListener('click', event => {
-    document.querySelector('#myModal').remove();
-  })
+  if(closeButton) {
+    closeButton.addEventListener('click', event => {
+      // event.currentTarget.closest('.modal').remove()
+      // document.body.classList.remove("modal-open")
+      // document.querySelector('.modal-backdrop').remove()
+      $("#exampleModal").modal("hide")
+    })
+  }
+
+
+  const cancelButton = document.querySelector('#cancel_edit')
+
+  if(cancelButton) {
+    cancelButton.addEventListener('click', event => {
+      document.querySelector('#myModal').remove();
+    })
+  }
 });
 
 

--- a/app/views/flower_subscriptions/index.html.erb
+++ b/app/views/flower_subscriptions/index.html.erb
@@ -37,7 +37,8 @@
                       <form class="simple_form new_flower_subscription" id="new_flower_subscription" novalidate="novalidate" action="/flower_subscriptions" accept-charset="UTF-8" method="post">
                         <input type="hidden" name="authenticity_token" value="am1OVWFikNBqB9tHD46TQGNeI1VymaafKVSF6qD3LxPZCTq/SFxraUeLDdeQ2OvUmCQKWcVS97XylwH3BwgzGg==">
 
-                           <h1 class="header-bouquettype">
+
+                <h1 class="header-bouquettype">
                             What size do you want your bouquet to be?
                           </h1>
                           <hr>
@@ -250,17 +251,17 @@
                     </form>
 
                     <!-- Modal -->
-                    <div class="modal fade" id="exampleModal" tabindex="-1" aria-labelledby="exampleModalLabel" aria-hidden="true">
+                    <div class="modal" id="exampleModal" tabindex="-1" aria-labelledby="exampleModalLabel" aria-hidden="true">
                       <div class="col-lg-4 col-md-6 col-sm-9 modal-dialog-subs">
                         <div class="modal-content-subs">
                           <div class="modal-header-subs">
                             <h5 class="modal-title-subs" id="exampleModalLabel">Sign Up</h5>
-                            <button type="button" class="close" data-dismiss="modal-dialog-subs" aria-label="Close">
+                            <button type="button" class="close" data-dismiss="modal-dialog-subs" aria-label="Close" id="close_button">
                               <span aria-hidden="true">&times;</span>
                             </button>
                           </div>
                           <div class="modal-body-subs">
-                            <%= simple_form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
+                            <%= simple_form_for(resource, as: resource_name, url: registration_path(resource_name), remote: true) do |f| %>
                             <%= f.error_notification %>
 
                             <div class="form-inputs-subs">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
-  devise_for :users
+  devise_for :users, controllers: { registrations: "registrations" }
   root to: 'pages#home'
   resources :users
   resources :flower_subscriptions


### PR DESCRIPTION
Final edit on the modal on the subscriptions page.
Made the close button work + after signing in /up your will stay on the subscriptions page, instead of being redericted to or sign up form page or empty opage with nav of logged in person. 

Also
Added a registrations controller page for the next step for us to safe the choices of the user, after signing in. This data needs to be saved, but isnt. You get back at an empty page. This means that or we need to delete the modal and add a submit button, and there the choices will be saved temporarly, and then after that you can be redirected to sign up. OR we create a area /session where this data is saved for the user, and will be shown after the user signed up on the modal. 